### PR TITLE
chore: Error handling of makeRequest function

### DIFF
--- a/src/createClient.ts
+++ b/src/createClient.ts
@@ -47,6 +47,11 @@ const createClient = ({ serviceDomain, apiKey, globalDraftKey }: ClientParams) =
 
     try {
       const response = await fetch(url, baseHeaders);
+
+      if (!response.ok) {
+        throw new Error(`fetch API response status: ${response.status}`);
+      }
+
       return response.json();
     } catch (error) {
       if (error.data) {
@@ -57,7 +62,9 @@ const createClient = ({ serviceDomain, apiKey, globalDraftKey }: ClientParams) =
         throw error.response.data;
       }
 
-      throw error;
+      return Promise.reject(
+        new Error(`serviceDomain or endpoint may be wrong.\n Details: ${error}`)
+      );
     }
   };
 


### PR DESCRIPTION
https://github.com/wantainc/microcms-js-sdk/issues/9
エラーハンドリング関連でPRさせていただきます。

```javascript
const client = createClient({
  serviceDomain: "YOUR_DOMAIN",
  apiKey: "YOUR_API_KEY",
});
```
上記の定義時に`serviceDomain`を間違えると`makeRequest`関数内の`fetch`で”404”になり、同関数の`catch (error) {}` 内でエラーがキャッチされていない気がしました。

**検証内容** （/example/javascript のサンプルコードを使用）
存在しないであろうserviceDomainを入力した場合は下記の様なエラーがでます。

* `Uncaught (in promise) SyntaxError: Unexpected end of JSON input`

しかし、これは`makeRequest`関数内の`catch (error) {}` ではない場所からthrowされていると思われます。
（エラー発生の行がコンソールに出力されていない）

MDNからの一部引用ですが、`fetch()`は404の場合エラーをthrowしない様ですね。

> ネットワークエラーに遭遇すると  [fetch()](https://developer.mozilla.org/ja/docs/Web/API/WindowOrWorkerGlobalScope/fetch)  promise は  [TypeError](https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/TypeError)  を返して reject 状態になります。サーバー側の CORS が適切に設定されていない場合も同様です(アクセス権の問題ですけどね) — 一方で例えば 404 はネットワークエラーを構成しません。

[Fetch の使用 - Web API | MDN](https://developer.mozilla.org/ja/docs/Web/API/Fetch_API/Using_Fetch)

fetchに失敗した場合は適切にエラーが表示された方がよいかと思いますので、`makeRequest`関数内については`response.ok`でエラーハンドリングした方が良いかもと思いました。
この変更によってコンソールにエラー箇所が表示されているかと思います。

エラーメッセージはもう少し表現を変えても良いかなと悩みました... 適宜変更していただければと思います。